### PR TITLE
remove custom field from PO and spec

### DIFF
--- a/cypress/e2e/page_objects/my_profile_page.js
+++ b/cypress/e2e/page_objects/my_profile_page.js
@@ -39,14 +39,6 @@ class PersonalDetails extends MyProfilePage {
     return cy.get(".--gender-grouped-field").contains(gender);
   }
 
-  getSmokerCheckBox() {
-    return cy
-      .xpath(
-        "//label[contains(text(),'Smoker')]//following::input[@type='checkbox']"
-      )
-      .eq(0);
-  }
-
   selectBirthdateOnCalendar() {
     let birthYears = [1988, 1995, 2005];
     let birthYear = birthYears[Math.floor(Math.random() * birthYears.length)];

--- a/cypress/e2e/spec/main_menu/my_profile/personal_details_spec.js
+++ b/cypress/e2e/spec/main_menu/my_profile/personal_details_spec.js
@@ -21,7 +21,6 @@ describe("User is able to update Personal Details in profile", () => {
     personalDetails.getBirthdateCalendar().click();
     personalDetails.selectBirthdateOnCalendar();
     personalDetails.getGenderRole("Male").click();
-    personalDetails.getSmokerCheckBox().check({ force: true });
     personalDetails.getButtonByName("Save").click();
     cy.get(".oxd-toast-container").should("be.visible");
     personalDetails


### PR DESCRIPTION
personal_details_spec.js failed
 due to custom field being removed from the user's profile page

Fixed the failing spec by removing the getter from the page object as well as the action to click the element within the spec. 

<img width="385" alt="image" src="https://github.com/user-attachments/assets/832e51a4-3d18-417e-99ac-13d5f01f19a9">

![image](https://github.com/user-attachments/assets/4cc0f75b-8218-40ab-83da-117b59aa8bc2)
